### PR TITLE
Remove parse from endpoints path

### DIFF
--- a/lib/parse_object.dart
+++ b/lib/parse_object.dart
@@ -13,7 +13,7 @@ class ParseObject implements ParseBaseObject {
   String get objectId => objectData['objectId'];
 
   ParseObject(this.className) {
-    path = "/parse/classes/$className";
+    path = "/classes/$className";
   }
 
   Future<Map> create([Map<String, dynamic> objectInitialData]) async {

--- a/lib/parse_user.dart
+++ b/lib/parse_user.dart
@@ -9,7 +9,7 @@ import 'parse_http_client.dart';
 class User implements ParseBaseObject {
   final String className = '_User';
   final ParseHTTPClient client = ParseHTTPClient();
-  String path = "/parse/classes/_User";
+  String path = "/classes/_User";
   Map<String, dynamic> objectData = {};
 
   static ParseUserData userData;
@@ -85,7 +85,7 @@ class User implements ParseBaseObject {
   Future<Map<String, dynamic>> login() async {
 
     Uri url = new Uri(
-        path: "${client.data.serverUrl}/parse/login",
+        path: "${client.data.serverUrl}/login",
         queryParameters: {
           "username": userData.username,
           "password": userData.password
@@ -102,7 +102,7 @@ class User implements ParseBaseObject {
 
   Future<Map<String, dynamic>> verificationEmailRequest() async {
     final response = this.client.post(
-        "${client.data.serverUrl}/parse/verificationEmailRequest",
+        "${client.data.serverUrl}/verificationEmailRequest",
         body: JsonEncoder().convert({"email": userData.emailAddress}));
     return response.then((value) {
       return _handleResponse(value.body);
@@ -111,7 +111,7 @@ class User implements ParseBaseObject {
 
   Future<Map<String, dynamic>> requestPasswordReset() async {
     final response = this.client.post(
-        "${client.data.serverUrl}/parse/requestPasswordReset",
+        "${client.data.serverUrl}/requestPasswordReset",
         body: JsonEncoder().convert({"email": userData.emailAddress}));
     return response.then((value) {
       return _handleResponse(value.body);


### PR DESCRIPTION
"parse" shouldn't be included in endpoint path, because if someone have domain dedicated just for Parse service (Parse is installed in root dir), this plugin will not work.