### PR TITLE
ParseData() should be initialized

### DIFF
--- a/lib/parse_http_client.dart
+++ b/lib/parse_http_client.dart
@@ -7,7 +7,7 @@ import 'package:parse_server_sdk/parse_data.dart';
 class ParseHTTPClient extends http.BaseClient {
   final http.Client _client = new http.Client();
   final String _userAgent = "Dart Parse SDK 0.1";
-  ParseData data;
+  ParseData data = ParseData();
 
   ParseHTTPClient();
 


### PR DESCRIPTION
Because data variable was never initialized, it was always null, and getting values like "masterKey" or "applicationId" will never work correctly. So, we need to initialize it first.